### PR TITLE
Add ssl attribute to AsyncHTTPClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+### TLS configuration
+
+``AsyncHTTPClient`` accepts an optional ``ssl`` context in its constructor or
+through :meth:`update_params`. This context will be passed to all requests if no
+``ssl`` argument is provided explicitly.

--- a/hexway_hive_api/rest/http_client/async_http_client.py
+++ b/hexway_hive_api/rest/http_client/async_http_client.py
@@ -2,10 +2,12 @@
 
 Attributes:
     session (aiohttp.ClientSession): Session used for all outgoing requests.
+    ssl (ssl.SSLContext | None): Default SSL context for requests.
 """
 
 from http import HTTPStatus, HTTPMethod
-from typing import Self, Union, MutableMapping, Any
+from typing import Self, Union, MutableMapping, Any, Optional
+import ssl
 
 import aiohttp
 
@@ -16,18 +18,29 @@ SUCCESSFUL_STATUS_CODES = [status for status in HTTPStatus if 200 <= status < 30
 
 class AsyncHTTPClient:
     """Asynchronous implementation of the HTTP client."""
-    def __init__(self) -> None:
-        """Create ``aiohttp`` session used for all requests."""
+    def __init__(self, *, ssl: Optional[ssl.SSLContext] = None) -> None:
+        """Create ``aiohttp`` session used for all requests.
+
+        Parameters
+        ----------
+        ssl : :class:`ssl.SSLContext` | None
+            Default SSL context applied to all requests.
+        """
 
         self.session: aiohttp.ClientSession = aiohttp.ClientSession()
         self._proxies: MutableMapping[str, str] = {}
+        self.ssl = ssl
 
     async def _send(self, method: HTTPMethod, url: str, **kwargs) -> Union[dict, bytes, list]:
-        """Internal helper performing HTTP request and parsing the response."""
+        """Internal helper performing HTTP request and parsing the response.
+
+        The default SSL context is appended to ``kwargs`` if not specified.
+        """
 
         proxy = self._proxies.get('https' if url.startswith('https') else 'http')
         if proxy:
             kwargs.setdefault('proxy', proxy)
+        kwargs.setdefault('ssl', self.ssl)
         try:
             async with self.session.request(method, url, **kwargs) as response:
                 if response.status not in SUCCESSFUL_STATUS_CODES:
@@ -97,8 +110,9 @@ class AsyncHTTPClient:
         return self
 
     def update_params(self, **kwargs) -> Self:
-        """Public wrapper around :meth:`_update_params`."""
-
+        """Update session parameters and store ``ssl`` for later use."""
+        if 'ssl' in kwargs:
+            self.ssl = kwargs['ssl']
         self._update_params(**kwargs)
         return self
 

--- a/tests/test_async_http_client.py
+++ b/tests/test_async_http_client.py
@@ -1,0 +1,62 @@
+import asyncio
+import ssl
+
+from hexway_hive_api.rest.http_client.async_http_client import AsyncHTTPClient
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.status = 200
+
+    async def json(self):
+        return {}
+
+    async def read(self):
+        return b""
+
+    async def text(self):
+        return ""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.headers = {}
+        self.kwargs = None
+        self.closed = False
+
+    def request(self, *args, **kwargs):
+        self.kwargs = kwargs
+        return DummyResponse()
+
+    async def close(self):
+        self.closed = True
+
+
+def test_update_params_sets_ssl():
+    async def run() -> None:
+        client = AsyncHTTPClient()
+        context = ssl.create_default_context()
+        client.update_params(ssl=context)
+        assert client.ssl is context
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_send_uses_default_ssl():
+    async def run() -> None:
+        client = AsyncHTTPClient()
+        client.session = DummySession()
+        context = ssl.create_default_context()
+        client.update_params(ssl=context)
+        await client.get("http://example.com")
+        assert client.session.kwargs.get("ssl") is context
+        await client.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- support passing a default ssl context to AsyncHTTPClient
- default ssl context is set through constructor or update_params
- use stored context for each HTTP call
- document TLS usage
- add tests for new ssl behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a55dde448330af5f270639c7b8fd