### PR TITLE
Add SSL context connect test

### DIFF
--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -56,3 +56,56 @@ def test_disconnect_closes_session() -> None:
 
     import asyncio
     asyncio.run(run())
+
+
+def test_connect_uses_ssl_context(monkeypatch) -> None:
+    """SSL context from ``cert`` parameter should be passed to requests."""
+    import ssl
+    async def run() -> None:
+        captured = None
+
+        # avoid loading real certificate
+        monkeypatch.setattr(
+            AsyncRestClient,
+            "_make_ssl_context",
+            staticmethod(lambda cert: ssl.create_default_context()),
+        )
+
+        client = AsyncRestClient(cert="path/to/cert.pem")
+
+        async def dummy_request(self, method, url, **kwargs):
+            nonlocal captured
+            captured = kwargs.get("ssl")
+            class DummyResponse:
+                def __init__(self) -> None:
+                    self.cookies = {"BSESSIONID": "cookie"}
+
+                async def json(self):
+                    return {}
+
+            return DummyResponse()
+
+        from types import MethodType
+
+        monkeypatch.setattr(
+            client.http_client.session,
+            "request",
+            MethodType(dummy_request, client.http_client.session),
+        )
+
+        async def dummy_post(self, url, **kwargs):
+            return await self.request("POST", url, ssl=client.http_client.ssl, **kwargs)
+
+        monkeypatch.setattr(
+            client.http_client.session,
+            "post",
+            MethodType(dummy_post, client.http_client.session),
+        )
+
+        await client.connect(server="https://hive.local", api_url="https://hive.local/api", username="u", password="p")
+
+        assert isinstance(captured, ssl.SSLContext)
+        await client.http_client.session.close()
+
+    import asyncio
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- cover SSL context forwarding during client connect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a6d7168883308129ae5f6d15d935