### PR TITLE
Ensure SSL context used on connect

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -99,10 +99,14 @@ class AsyncRestClient:
         if '@' not in username:
             username = f'{username}@ro.ot'
 
-        response = await self.http_client.session.post(f"{self.api_url}/session", json={
-            'userLogin': username,
-            'userPassword': password,
-        })
+        response = await self.http_client.session.post(
+            f"{self.api_url}/session",
+            json={
+                'userLogin': username,
+                'userPassword': password,
+            },
+            ssl=self.http_client.ssl,
+        )
 
         cookie = response.cookies.get('BSESSIONID')
         if not cookie:

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -61,9 +61,8 @@ def test_disconnect_closes_session() -> None:
 def test_connect_uses_ssl_context(monkeypatch) -> None:
     """SSL context from ``cert`` parameter should be passed to requests."""
     import ssl
-    async def run() -> None:
-        captured = None
 
+    async def run() -> None:
         # avoid loading real certificate
         monkeypatch.setattr(
             AsyncRestClient,
@@ -71,40 +70,36 @@ def test_connect_uses_ssl_context(monkeypatch) -> None:
             staticmethod(lambda cert: ssl.create_default_context()),
         )
 
+        class DummyResponse:
+            def __init__(self) -> None:
+                self.cookies = {"BSESSIONID": "cookie"}
+
+        class DummySession:
+            def __init__(self) -> None:
+                self.headers = {}
+                self.captured = None
+                self.closed = False
+
+            async def post(self, *args, **kwargs):
+                self.captured = kwargs.get("ssl")
+                return DummyResponse()
+
+            async def close(self):
+                self.closed = True
+
         client = AsyncRestClient(cert="path/to/cert.pem")
+        old_session = client.http_client.session
+        client.http_client.session = DummySession()
+        await old_session.close()
 
-        async def dummy_request(self, method, url, **kwargs):
-            nonlocal captured
-            captured = kwargs.get("ssl")
-            class DummyResponse:
-                def __init__(self) -> None:
-                    self.cookies = {"BSESSIONID": "cookie"}
-
-                async def json(self):
-                    return {}
-
-            return DummyResponse()
-
-        from types import MethodType
-
-        monkeypatch.setattr(
-            client.http_client.session,
-            "request",
-            MethodType(dummy_request, client.http_client.session),
+        await client.connect(
+            server="https://hive.local",
+            api_url="https://hive.local/api",
+            username="u",
+            password="p",
         )
 
-        async def dummy_post(self, url, **kwargs):
-            return await self.request("POST", url, ssl=client.http_client.ssl, **kwargs)
-
-        monkeypatch.setattr(
-            client.http_client.session,
-            "post",
-            MethodType(dummy_post, client.http_client.session),
-        )
-
-        await client.connect(server="https://hive.local", api_url="https://hive.local/api", username="u", password="p")
-
-        assert isinstance(captured, ssl.SSLContext)
+        assert isinstance(client.http_client.session.captured, ssl.SSLContext)
         await client.http_client.session.close()
 
     import asyncio


### PR DESCRIPTION
## Summary
- pass stored SSL context to aiohttp POST request when connecting
- simplify async REST client test to check SSL argument automatically

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ac602f148330a980dac88c293a42