### PR TITLE
Fix session recreation logic

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -90,6 +90,13 @@ class AsyncRestClient:
             context = self._make_ssl_context(cert)
             self.http_client.update_params(ssl=context)
 
+        if self.http_client.session.closed:
+            proxies = self.http_client.proxies
+            ssl_context = self.http_client.ssl
+            await self.http_client.close()
+            self.http_client = AsyncHTTPClient(ssl=ssl_context)
+            self.http_client.proxies = proxies
+
         self.server = server or self.server
         self.api_url = api_url or self.api_url or self.make_api_url_from(self.server)
 
@@ -117,11 +124,14 @@ class AsyncRestClient:
 
     async def disconnect(self) -> bool:
         """Close connection and clean up client session."""
-
         await self.http_client.session.delete(f"{self.api_url}/session")
         self.state = ClientState.DISCONNECTED
         await self.http_client.clear_session()
+        proxies = self.http_client.proxies
+        ssl_context = self.http_client.ssl
         await self.http_client.close()
+        self.http_client = AsyncHTTPClient(ssl=ssl_context)
+        self.http_client.proxies = proxies
         return True
 
     @asynccontextmanager

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -35,9 +35,13 @@ def test_disconnect_closes_session() -> None:
             self.closed = False
 
         async def post(self, *args, **kwargs):
+            if self.closed:
+                raise RuntimeError("Session is closed")
             return DummyResponse()
 
         async def delete(self, *args, **kwargs):
+            if self.closed:
+                raise RuntimeError("Session is closed")
             return DummyResponse()
 
         async def close(self):
@@ -46,13 +50,69 @@ def test_disconnect_closes_session() -> None:
     async def run() -> None:
         client = AsyncRestClient()
         old_session = client.http_client.session
-        client.http_client.session = DummySession()
+        dummy = DummySession()
+        client.http_client.session = dummy
         await old_session.close()
 
         await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
         await client.disconnect()
 
-        assert client.http_client.session.closed is True
+        assert dummy.closed is True
+        assert client.http_client.session is not dummy
+        assert client.http_client.session.closed is False
+
+    import asyncio
+    asyncio.run(run())
+
+
+def test_connect_after_disconnect() -> None:
+    """Client should be able to reconnect after disconnect."""
+
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.cookies = {"BSESSIONID": "cookie"}
+
+        async def json(self):
+            return {}
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers = {}
+            self.closed = False
+
+        async def post(self, *args, **kwargs):
+            if self.closed:
+                raise RuntimeError("Session is closed")
+            return DummyResponse()
+
+        async def delete(self, *args, **kwargs):
+            if self.closed:
+                raise RuntimeError("Session is closed")
+            return DummyResponse()
+
+        async def close(self):
+            self.closed = True
+
+    async def run() -> None:
+        client = AsyncRestClient()
+        old_session = client.http_client.session
+        dummy1 = DummySession()
+        client.http_client.session = dummy1
+        await old_session.close()
+
+        await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
+        await client.disconnect()
+
+        new_real_session = client.http_client.session
+        dummy2 = DummySession()
+        client.http_client.session = dummy2
+        await new_real_session.close()
+
+        await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
+
+        assert dummy2.closed is False
+        assert client.http_client.session.headers.get("Cookie") == "BSESSIONID=cookie"
+        await client.http_client.session.close()
 
     import asyncio
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- recreate HTTP session when disconnecting the async client
- reconnect using a new session when the previous one is closed
- test reconnect behaviour

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684917e7507483308a15eeb3a3e0f897