### PR TITLE
Add aiohttp error handling in AsyncRestClient.connect

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -2,6 +2,8 @@
 
 import json
 import ssl
+
+import aiohttp
 from contextlib import asynccontextmanager
 from typing import Optional, MutableMapping, Union, Self, AsyncGenerator
 from uuid import UUID
@@ -106,14 +108,18 @@ class AsyncRestClient:
         if '@' not in username:
             username = f'{username}@ro.ot'
 
-        response = await self.http_client.session.post(
-            f"{self.api_url}/session",
-            json={
-                'userLogin': username,
-                'userPassword': password,
-            },
-            ssl=self.http_client.ssl,
-        )
+        try:
+            response = await self.http_client.session.post(
+                f"{self.api_url}/session",
+                json={
+                    'userLogin': username,
+                    'userPassword': password,
+                },
+                ssl=self.http_client.ssl,
+            )
+        except aiohttp.ClientError as e:
+            await self.http_client.close()
+            raise exceptions.RestConnectionError(f'Failed to connect: {e}') from e
 
         cookie = response.cookies.get('BSESSIONID')
         if not cookie:

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -1,4 +1,7 @@
 from hexway_hive_api.clients.async_rest_client import AsyncRestClient
+from hexway_hive_api.rest import exceptions
+import aiohttp
+import pytest
 
 
 def test_make_api_url_from() -> None:
@@ -14,6 +17,36 @@ def test_proxies_property() -> None:
         client.proxies = {"http": "http://proxy"}
         assert client.proxies.get("http") == "http://proxy"
         await client.http_client.clear_session()
+
+    import asyncio
+    asyncio.run(run())
+
+
+def test_connect_handles_aiohttp_error() -> None:
+    """Client should close session and raise ``RestConnectionError`` on aiohttp failure."""
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers = {}
+            self.closed = False
+
+        async def post(self, *args, **kwargs):
+            raise aiohttp.ClientConnectionError("boom")
+
+        async def close(self):
+            self.closed = True
+
+    async def run() -> None:
+        client = AsyncRestClient()
+        old_session = client.http_client.session
+        dummy = DummySession()
+        client.http_client.session = dummy
+        await old_session.close()
+
+        with pytest.raises(exceptions.RestConnectionError):
+            await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
+
+        assert dummy.closed is True
 
     import asyncio
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- handle `aiohttp.ClientError` when posting session in `AsyncRestClient.connect`
- close session on error and raise `RestConnectionError`
- test the new error path

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491aa2dbc083308738095e9e4d4a65