### PR TITLE
Fix AsyncRestClient.disconnect

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -130,14 +130,19 @@ class AsyncRestClient:
 
     async def disconnect(self) -> bool:
         """Close connection and clean up client session."""
-        await self.http_client.session.delete(f"{self.api_url}/session")
-        self.state = ClientState.DISCONNECTED
-        await self.http_client.clear_session()
-        proxies = self.http_client.proxies
-        ssl_context = self.http_client.ssl
-        await self.http_client.close()
-        self.http_client = AsyncHTTPClient(ssl=ssl_context)
-        self.http_client.proxies = proxies
+        try:
+            await self.http_client.session.delete(f"{self.api_url}/session")
+        except aiohttp.ClientError:
+            # connection may already be closed by the server
+            pass
+        finally:
+            self.state = ClientState.DISCONNECTED
+            await self.http_client.clear_session()
+            proxies = self.http_client.proxies
+            ssl_context = self.http_client.ssl
+            await self.http_client.close()
+            self.http_client = AsyncHTTPClient(ssl=ssl_context)
+            self.http_client.proxies = proxies
         return True
 
     @asynccontextmanager

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -98,6 +98,50 @@ def test_disconnect_closes_session() -> None:
     asyncio.run(run())
 
 
+def test_disconnect_handles_server_error() -> None:
+    """Disconnect should recreate session even if server is already disconnected."""
+
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.cookies = {"BSESSIONID": "cookie"}
+
+        async def json(self):
+            return {}
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers = {}
+            self.closed = False
+
+        async def post(self, *args, **kwargs):
+            if self.closed:
+                raise RuntimeError("Session is closed")
+            return DummyResponse()
+
+        async def delete(self, *args, **kwargs):
+            raise aiohttp.ServerDisconnectedError()
+
+        async def close(self):
+            self.closed = True
+
+    async def run() -> None:
+        client = AsyncRestClient()
+        old_session = client.http_client.session
+        dummy = DummySession()
+        client.http_client.session = dummy
+        await old_session.close()
+
+        await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
+        await client.disconnect()
+
+        assert dummy.closed is True
+        assert client.http_client.session is not dummy
+        assert client.http_client.session.closed is False
+
+    import asyncio
+    asyncio.run(run())
+
+
 def test_connect_after_disconnect() -> None:
     """Client should be able to reconnect after disconnect."""
 


### PR DESCRIPTION
## Summary
- cleanly handle aiohttp errors during disconnect
- test disconnect when ServerDisconnectedError is raised

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68491bff3574833089b8bc74d2bf6ae7