### PR TITLE
Fix session reuse logic for async client

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -141,8 +141,8 @@ class AsyncRestClient:
             proxies = self.http_client.proxies
             ssl_context = self.http_client.ssl
             await self.http_client.close()
-            self.http_client = AsyncHTTPClient(ssl=ssl_context)
             self.http_client.proxies = proxies
+            self.http_client.ssl = ssl_context
         return True
 
     @asynccontextmanager

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -91,8 +91,8 @@ def test_disconnect_closes_session() -> None:
         await client.disconnect()
 
         assert dummy.closed is True
-        assert client.http_client.session is not dummy
-        assert client.http_client.session.closed is False
+        assert client.http_client.session is dummy
+        assert client.http_client.session.closed is True
 
     import asyncio
     asyncio.run(run())
@@ -135,8 +135,8 @@ def test_disconnect_handles_server_error() -> None:
         await client.disconnect()
 
         assert dummy.closed is True
-        assert client.http_client.session is not dummy
-        assert client.http_client.session.closed is False
+        assert client.http_client.session is dummy
+        assert client.http_client.session.closed is True
 
     import asyncio
     asyncio.run(run())
@@ -180,10 +180,12 @@ def test_connect_after_disconnect() -> None:
         await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
         await client.disconnect()
 
-        new_real_session = client.http_client.session
+        assert dummy1.closed is True
+        assert client.http_client.session is dummy1
+        assert client.http_client.session.closed is True
+
         dummy2 = DummySession()
         client.http_client.session = dummy2
-        await new_real_session.close()
 
         await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
 


### PR DESCRIPTION
## Summary
- keep the same HTTP client after disconnect
- ensure disconnect leaves a closed session
- update async tests for new behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489b0a65e88330b98f298dd0208cdf