### PR TITLE
Add verify flag support for AsyncRestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,5 @@ through :meth:`update_params`. This context will be passed to all requests if no
 ``ssl`` argument is provided explicitly. Verification of server certificates can
 be toggled via the ``verify_ssl`` flag or ``verify`` parameter in
 :meth:`update_params` and individual request methods. Disabling verification will
-still keep TLS encryption enabled.
+still keep TLS encryption enabled. ``AsyncRestClient.connect`` also respects the
+``verify`` / ``verify_ssl`` options when establishing the session.

--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -86,6 +86,7 @@ class AsyncRestClient:
             raise exceptions.RestConnectionError('You must provide username and password.')
 
         cert = other.pop('cert', None) or self.cert
+        verify = other.get("verify", other.get("verify_ssl", self.http_client.verify_ssl))
         self.http_client.update_params(**other)
         if cert:
             self.cert = cert
@@ -109,13 +110,21 @@ class AsyncRestClient:
             username = f'{username}@ro.ot'
 
         try:
+            ssl_context = self.http_client.ssl
+            if verify is False:
+                if ssl_context is not None:
+                    ssl_context = ssl.SSLContext(ssl_context.protocol)
+                else:
+                    ssl_context = ssl.create_default_context()
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
             response = await self.http_client.session.post(
                 f"{self.api_url}/session",
                 json={
                     'userLogin': username,
                     'userPassword': password,
                 },
-                ssl=self.http_client.ssl,
+                ssl=ssl_context,
             )
         except aiohttp.ClientError as e:
             await self.http_client.close()

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -1,4 +1,13 @@
-from hexway_hive_api.clients.async_rest_client import AsyncRestClient
+import os
+import sys
+import importlib.util
+local_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+module_path = os.path.join(local_path, 'hexway_hive_api', 'clients', 'async_rest_client.py')
+spec = importlib.util.spec_from_file_location('hexway_hive_api.clients.async_rest_client', module_path)
+async_rest_client = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(async_rest_client)
+sys.modules['hexway_hive_api.clients.async_rest_client'] = async_rest_client
+AsyncRestClient = async_rest_client.AsyncRestClient
 from hexway_hive_api.rest import exceptions
 import aiohttp
 import pytest
@@ -17,6 +26,48 @@ def test_proxies_property() -> None:
         client.proxies = {"http": "http://proxy"}
         assert client.proxies.get("http") == "http://proxy"
         await client.http_client.clear_session()
+
+    import asyncio
+    asyncio.run(run())
+
+
+def test_connect_respects_verify_false() -> None:
+    """SSL context should disable verification when verify is False."""
+    import ssl
+
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.cookies = {"BSESSIONID": "cookie"}
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers = {}
+            self.captured = None
+            self.closed = False
+
+        async def post(self, *args, **kwargs):
+            self.captured = kwargs.get("ssl")
+            return DummyResponse()
+
+        async def close(self):
+            self.closed = True
+
+    async def run() -> None:
+        client = AsyncRestClient()
+        old_session = client.http_client.session
+        client.http_client.session = DummySession()
+        await old_session.close()
+        await client.connect(
+            server="https://hive.local",
+            api_url="https://hive.local/api",
+            username="u",
+            password="p",
+            verify=False,
+        )
+        context = client.http_client.session.captured
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_NONE
+        await client.http_client.session.close()
 
     import asyncio
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- allow AsyncRestClient.connect to disable TLS verification
- clarify README TLS section
- test verify=False path in AsyncRestClient.connect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aac2810c08330abb1ffae127c5837