### PR TITLE
Fix headers merge and update cookie handling tests

### DIFF
--- a/hexway_hive_api/rest/http_client/async_http_client.py
+++ b/hexway_hive_api/rest/http_client/async_http_client.py
@@ -129,9 +129,13 @@ class AsyncHTTPClient:
         return await self._send(HTTPMethod.DELETE, *args, **kwargs)
 
     def add_headers(self, headers: dict) -> Self:
-        """Inject additional headers into requests session."""
+        """Inject additional headers into requests session without duplicates."""
 
-        self.session.headers.update(headers)
+        for key, value in headers.items():
+            if value is None:
+                self.session.headers.pop(key, None)
+            else:
+                self.session.headers[key] = value
         return self
 
     def update_params(self, **kwargs) -> Self:

--- a/hexway_hive_api/rest/http_client/http_client.py
+++ b/hexway_hive_api/rest/http_client/http_client.py
@@ -75,8 +75,12 @@ class HTTPClient:
         return self._send(HTTPMethod.DELETE, *args, **kwargs)
 
     def add_headers(self, headers: dict) -> Self:
-        """Method injects headers into session."""
-        self.session.headers.update(headers)
+        """Merge provided headers into the session without duplicates."""
+        for key, value in headers.items():
+            if value is None:
+                self.session.headers.pop(key, None)
+            else:
+                self.session.headers[key] = value
         return self
 
     def update_params(self, **kwargs) -> Self:

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -13,6 +13,11 @@ import aiohttp
 import pytest
 
 
+class DummyCookie:
+    def __init__(self, value: str = "cookie") -> None:
+        self.value = value
+
+
 def test_make_api_url_from() -> None:
     """Ensure API URL is built correctly from server string."""
     url = AsyncRestClient.make_api_url_from('https://hive.local')
@@ -37,7 +42,7 @@ def test_connect_respects_verify_false() -> None:
 
     class DummyResponse:
         def __init__(self) -> None:
-            self.cookies = {"BSESSIONID": "cookie"}
+            self.cookies = {"BSESSIONID": DummyCookie()}
 
     class DummySession:
         def __init__(self) -> None:
@@ -108,7 +113,7 @@ def test_disconnect_closes_session() -> None:
 
     class DummyResponse:
         def __init__(self) -> None:
-            self.cookies = {"BSESSIONID": "cookie"}
+            self.cookies = {"BSESSIONID": DummyCookie()}
 
         async def json(self):
             return {}
@@ -154,7 +159,7 @@ def test_disconnect_handles_server_error() -> None:
 
     class DummyResponse:
         def __init__(self) -> None:
-            self.cookies = {"BSESSIONID": "cookie"}
+            self.cookies = {"BSESSIONID": DummyCookie()}
 
         async def json(self):
             return {}
@@ -198,7 +203,7 @@ def test_connect_after_disconnect() -> None:
 
     class DummyResponse:
         def __init__(self) -> None:
-            self.cookies = {"BSESSIONID": "cookie"}
+            self.cookies = {"BSESSIONID": DummyCookie()}
 
         async def json(self):
             return {}
@@ -262,7 +267,7 @@ def test_connect_uses_ssl_context(monkeypatch) -> None:
 
         class DummyResponse:
             def __init__(self) -> None:
-                self.cookies = {"BSESSIONID": "cookie"}
+                self.cookies = {"BSESSIONID": DummyCookie()}
 
         class DummySession:
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- fix header merging logic to avoid duplicate values
- adjust async tests to use a dummy cookie object

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea7c645fc83308eecf5e815168ce4