### PR TITLE
Fix duplicated headers in async HTTP client

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -138,7 +138,7 @@ class AsyncRestClient:
         if not cookie:
             raise exceptions.RestConnectionError('Could not get authentication cookie. Something wrong with credentials or server.')
 
-        self.http_client.add_headers({'Cookie': f'BSESSIONID={cookie}'})
+        self.http_client._cookie_header = f'BSESSIONID={cookie}'
         self.state = ClientState.CONNECTED
 
     async def disconnect(self) -> bool:

--- a/hexway_hive_api/rest/http_client/async_http_client.py
+++ b/hexway_hive_api/rest/http_client/async_http_client.py
@@ -32,10 +32,13 @@ class AsyncHTTPClient:
             Flag controlling TLS certificate verification. ``True`` by default.
         """
 
-        self.session: aiohttp.ClientSession = aiohttp.ClientSession()
+        self.session: aiohttp.ClientSession = aiohttp.ClientSession(
+            skip_auto_headers={"Accept-Encoding"}
+        )
         self._proxies: MutableMapping[str, str] = {}
         self.ssl = ssl
         self.verify_ssl = verify_ssl
+        self._cookie_header: Optional[str] = None
 
     async def _send(self, method: HTTPMethod, url: str, **kwargs) -> Union[dict, bytes, list]:
         """Internal helper performing HTTP request and parsing the response.
@@ -46,6 +49,14 @@ class AsyncHTTPClient:
         proxy = self._proxies.get('https' if url.startswith('https') else 'http')
         if proxy:
             kwargs.setdefault('proxy', proxy)
+
+        headers = dict(kwargs.get("headers", {}))
+        if self._cookie_header and "Cookie" not in headers:
+            headers["Cookie"] = self._cookie_header
+        if "Accept-Encoding" in headers:
+            values = [v.strip() for v in headers["Accept-Encoding"].split(',')]
+            headers["Accept-Encoding"] = ", ".join(dict.fromkeys(values))
+        kwargs["headers"] = headers
 
         verify = kwargs.pop("verify", kwargs.pop("verify_ssl", self.verify_ssl))
 
@@ -96,6 +107,7 @@ class AsyncHTTPClient:
         """Remove all custom headers from the session."""
 
         self.session.headers.clear()
+        self._cookie_header = None
         return True
 
     async def close(self) -> bool:
@@ -128,15 +140,6 @@ class AsyncHTTPClient:
 
         return await self._send(HTTPMethod.DELETE, *args, **kwargs)
 
-    def add_headers(self, headers: dict) -> Self:
-        """Inject additional headers into requests session without duplicates."""
-
-        for key, value in headers.items():
-            if value is None:
-                self.session.headers.pop(key, None)
-            else:
-                self.session.headers[key] = value
-        return self
 
     def update_params(self, **kwargs) -> Self:
         """Update session parameters and store ``ssl`` for later use."""

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -246,7 +246,7 @@ def test_connect_after_disconnect() -> None:
         await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
 
         assert dummy2.closed is False
-        assert client.http_client.session.headers.get("Cookie") == "BSESSIONID=cookie"
+        assert client.http_client._cookie_header == "BSESSIONID=cookie"
         await client.http_client.session.close()
 
     import asyncio


### PR DESCRIPTION
## Summary
- stop persisting headers in AsyncHTTPClient
- inject cookie per request and allow Accept-Encoding deduplication
- store authentication cookie separately when connecting
- update tests for new behaviour
- remove User-Agent and Accept defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685eac601f688330986baab079ff10f4