### PR TITLE
Remove outdated cookie header handling

### DIFF
--- a/hexway_hive_api/clients/async_rest_client.py
+++ b/hexway_hive_api/clients/async_rest_client.py
@@ -137,8 +137,6 @@ class AsyncRestClient:
         cookie = response.cookies.get('BSESSIONID').value if response.cookies else None
         if not cookie:
             raise exceptions.RestConnectionError('Could not get authentication cookie. Something wrong with credentials or server.')
-
-        self.http_client._cookie_header = f'BSESSIONID={cookie}'
         self.state = ClientState.CONNECTED
 
     async def disconnect(self) -> bool:

--- a/hexway_hive_api/rest/http_client/async_http_client.py
+++ b/hexway_hive_api/rest/http_client/async_http_client.py
@@ -38,7 +38,6 @@ class AsyncHTTPClient:
         self._proxies: MutableMapping[str, str] = {}
         self.ssl = ssl
         self.verify_ssl = verify_ssl
-        self._cookie_header: Optional[str] = None
 
     async def _send(self, method: HTTPMethod, url: str, **kwargs) -> Union[dict, bytes, list]:
         """Internal helper performing HTTP request and parsing the response.
@@ -51,8 +50,6 @@ class AsyncHTTPClient:
             kwargs.setdefault('proxy', proxy)
 
         headers = dict(kwargs.get("headers", {}))
-        if self._cookie_header and "Cookie" not in headers:
-            headers["Cookie"] = self._cookie_header
         if "Accept-Encoding" in headers:
             values = [v.strip() for v in headers["Accept-Encoding"].split(',')]
             headers["Accept-Encoding"] = ", ".join(dict.fromkeys(values))
@@ -107,7 +104,6 @@ class AsyncHTTPClient:
         """Remove all custom headers from the session."""
 
         self.session.headers.clear()
-        self._cookie_header = None
         return True
 
     async def close(self) -> bool:

--- a/tests/test_async_rest_client.py
+++ b/tests/test_async_rest_client.py
@@ -212,10 +212,12 @@ def test_connect_after_disconnect() -> None:
         def __init__(self) -> None:
             self.headers = {}
             self.closed = False
+            self.cookie_jar = {}
 
         async def post(self, *args, **kwargs):
             if self.closed:
                 raise RuntimeError("Session is closed")
+            self.cookie_jar["BSESSIONID"] = DummyCookie()
             return DummyResponse()
 
         async def delete(self, *args, **kwargs):
@@ -246,7 +248,7 @@ def test_connect_after_disconnect() -> None:
         await client.connect(server="http://test", api_url="http://test/api", username="u", password="p")
 
         assert dummy2.closed is False
-        assert client.http_client._cookie_header == "BSESSIONID=cookie"
+        assert client.http_client.session.cookie_jar["BSESSIONID"].value == "cookie"
         await client.http_client.session.close()
 
     import asyncio


### PR DESCRIPTION
## Summary
- remove the `_cookie_header` mechanism from `AsyncHTTPClient`
- rely on the session cookie jar in `AsyncRestClient`
- update tests to inspect `cookie_jar`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb7d2029c8330a01419c8305fc25b